### PR TITLE
Add MCP server subcommand wrapping 4D LSP

### DIFF
--- a/tool4d-lsp-stdio/Cargo.lock
+++ b/tool4d-lsp-stdio/Cargo.lock
@@ -3,6 +3,24 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c982642fa9e8606056828ee9a8505737230110bb1099153c79efe865c59d12ba"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae221649c9976a6f6c56ae1facf410f3ddb33cc661c4b7b61020a912d4237fbc"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -59,6 +77,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
+name = "autocfg"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
+name = "base64"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
+
+[[package]]
 name = "bitflags"
 version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -74,6 +104,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "bumpalo"
+version = "3.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
+name = "bytes"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
+
+[[package]]
+name = "cc"
+version = "1.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ad534f4357a5264cce5019c989cf66a4f0dc4e0d1b1d15f8aacec0ff7360273"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -84,6 +136,18 @@ name = "cfg_aliases"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
+
+[[package]]
+name = "chrono"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
+dependencies = [
+ "iana-time-zone",
+ "num-traits",
+ "serde",
+ "windows-link",
+]
 
 [[package]]
 name = "clap"
@@ -116,7 +180,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -132,6 +196,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
 name = "ctrlc"
 version = "3.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -140,6 +210,40 @@ dependencies = [
  "dispatch2",
  "nix",
  "windows-sys",
+]
+
+[[package]]
+name = "darling"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed17f5901b6630b993ca003def43f2f8ef4014fc13b047b57aad617ff32bc2ec"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6837e2cf7485aaae18f86181d2f0e9a7ed297a025e220aeabf63fdebd3a2ddff"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 3.0.3",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ac7135c3ef02b2f7833bbeb1be5ba7f966dcde8a87c6b87f65a778d71a02785"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -155,6 +259,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
 name = "errno"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -165,10 +281,163 @@ dependencies = [
 ]
 
 [[package]]
+name = "find-msvc-tools"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890"
+
+[[package]]
+name = "futures"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a31d2a3fbaaeb2af2368bbdd904aa8e812d3c04a1ee10d3171f52d556e5d0a3"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f9e3d69d39e4862ffed03ed071a76f9a13ba1d9109d355b0f0aa6b15e393c4"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92d699e522242e69e3003b94ecc1f960f3a5e015aa7c5d7486e65ad01dd94f5e"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "031b47cf1a3c6cc8bc2fc76cd437f521619387907d469316e7c0bc278f1f5432"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53c0fa8157de1303bfffdaa1cc2a673bfffb60102f76b0ef4441659124373fed"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fb9654ba8355388abeb8dcb4fc62f511300867002afc858860463bdd9fe0c44"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1944426bf7d03f1d14f708785e4b33efd750b36d48a157b836b3efc15ede8e1d"
+
+[[package]]
+name = "futures-task"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd417de3d1d015fc3bfd2b1ea46dfc7bab72ef86f1cc7cc9c78e728b34a6d1fd"
+
+[[package]]
+name = "futures-util"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d50a92467f8ba5dd6e3ee5d4bd04d73ab2e4e1c44474a0674821dfce14b79bc"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "indexmap"
+version = "2.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07aa2048142242915a31d35844fb311e0e53fcca590c3a0a40dcf1b841fa09eb"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+ "serde",
+ "serde_core",
+]
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -183,16 +452,59 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "js-sys"
+version = "0.3.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e0c1080212aad755ea003d18543e8768dd432c48819efd73a7bf1e39b7a5a3a"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "libc"
 version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
+name = "log"
+version = "0.4.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9f8bd3e56ce4dfc153cf470fffbfa98c7620958b312ca5c3a4b8d5181fd13c6"
+
+[[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
+
+[[package]]
+name = "mio"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys",
+]
 
 [[package]]
 name = "nix"
@@ -204,6 +516,24 @@ dependencies = [
  "cfg-if",
  "cfg_aliases",
  "libc",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -222,10 +552,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
 
 [[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
 name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "pastey"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "proc-macro2"
@@ -243,6 +591,117 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "ref-cast"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e440fb4e4b4147295338efb76001ab9e4efc0e5839df2c47fc5ac2381d365c3"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92ecd8964f8453721699a1ed72037b0db49ce2f5a5138486ee89bed6f67cdf3a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
+
+[[package]]
+name = "rmcp"
+version = "3.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a15bc53261a9dc37e105df006e4656c598379a8f9581f8950debb130f27a7cf"
+dependencies = [
+ "base64",
+ "chrono",
+ "futures",
+ "indexmap",
+ "pastey",
+ "pin-project-lite",
+ "rmcp-macros",
+ "schemars",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "rmcp-macros"
+version = "3.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a85d45508e9b4ba024fe996c2638799635d75b6dd0ba8f32ccf08f8026f0c780"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "serde_json",
+ "syn 3.0.3",
+]
+
+[[package]]
+name = "rustversion"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
+
+[[package]]
+name = "schemars"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "687274d293b6cdc6e73e0fee520bf2049650090d7164f87672d212a3c530cf4a"
+dependencies = [
+ "chrono",
+ "dyn-clone",
+ "ref-cast",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98c67716b46af2f0b8cf752abc930f6f9aecfbf671ecfb531db8a31dbe4e2ba"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -272,7 +731,18 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f852137cce035d6a4df67ccce505ff6b3e9fd3a10e3e52b24dc71e650bb1a9bd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -287,6 +757,21 @@ dependencies = [
  "serde_core",
  "zmij",
 ]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-hook"
@@ -309,10 +794,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "smallvec"
+version = "1.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "syn"
+version = "2.0.119"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
 
 [[package]]
 name = "syn"
@@ -326,6 +834,75 @@ dependencies = [
 ]
 
 [[package]]
+name = "thiserror"
+version = "2.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "tokio"
+version = "1.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
+dependencies = [
+ "bytes",
+ "libc",
+ "mio",
+ "pin-project-lite",
+ "signal-hook-registry",
+ "tokio-macros",
+ "windows-sys",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "494815d09bf52b5548659851081238f0ca39ff638363907596da739561c62c52"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "libc",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "tool4d-lsp-stdio"
 version = "0.2.13"
 dependencies = [
@@ -333,11 +910,77 @@ dependencies = [
  "clap",
  "ctrlc",
  "libc",
+ "rmcp",
+ "schemars",
  "serde",
  "serde_json",
  "signal-hook",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
  "wait-timeout",
  "windows-sys",
+]
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -353,6 +996,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "uuid"
+version = "1.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5772d71c9be8a8a6ac2117d949c5b224c1b72241bb611d9a3012edcf8af7812"
+dependencies = [
+ "getrandom",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
 name = "wait-timeout"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -362,10 +1022,114 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.127"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b70935747edd64d89de3efa29d73789b806c15798f8e7dca4d8ac356b50ce70"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.127"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77775f8f3f7217702089053b94958f8f54061a3f663417df76e19cbdcca29bc1"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.127"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e11d33f857dc2fb11b8bc75aee111aa9cbeb12cd9f25efd3d4c2a3dd4e235284"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.127"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ef64dbcc55df09c7e5a46182d181c2cfa3e925f3da937ea764728b4bbb9dcbf"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"

--- a/tool4d-lsp-stdio/Cargo.toml
+++ b/tool4d-lsp-stdio/Cargo.toml
@@ -13,6 +13,11 @@ libc = "0.2"
 signal-hook = "0.3"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+rmcp = { version = "3.1", features = ["server", "macros", "transport-io"] }
+schemars = "1.0"
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "io-std", "signal"] }
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.61", features = [

--- a/tool4d-lsp-stdio/src/main.rs
+++ b/tool4d-lsp-stdio/src/main.rs
@@ -21,6 +21,8 @@ use clap::{ArgAction, Parser, Subcommand};
 use tool4d_lsp_stdio::process::{ChildGuard, configure_process_supervision};
 use tool4d_lsp_stdio::relay::{Relay, RelayEvent};
 
+mod mcp;
+
 #[derive(Debug, Parser)]
 #[command(
     name = "tool4d-lsp-stdio",
@@ -162,6 +164,59 @@ enum BridgeCommand {
         #[arg(required = true)]
         files: Vec<PathBuf>,
     },
+
+    /// Start an MCP server that wraps the 4D LSP.
+    ///
+    /// Keeps a persistent tool4d LSP session alive and exposes LSP
+    /// capabilities (validate, completion, hover, goto_definition,
+    /// document_symbols) as MCP tools over stdio.
+    Mcp {
+        /// Path to the tool4d executable.
+        #[arg(long, env = "TOOL4D_PATH")]
+        tool: Option<PathBuf>,
+
+        /// Explicit path to a .4DProject file.
+        #[arg(long, env = "TOOL4D_PROJECT")]
+        project: Option<PathBuf>,
+
+        /// Workspace in which to search for a .4DProject file.
+        #[arg(long)]
+        workspace: Option<PathBuf>,
+
+        /// Local TCP port on which the adapter listens for tool4d.
+        #[arg(long, env = "TOOL4D_LSP_PORT")]
+        port: Option<u16>,
+
+        /// Number of seconds to wait for tool4d to connect.
+        #[arg(long, env = "TOOL4D_STARTUP_TIMEOUT", default_value_t = 30)]
+        startup_timeout: u64,
+
+        /// Number of seconds to wait before force-killing tool4d.
+        #[arg(long, env = "TOOL4D_SHUTDOWN_TIMEOUT", default_value_t = 5)]
+        shutdown_timeout: u64,
+
+        /// Prevent execution of project startup database methods.
+        #[arg(
+            long,
+            env = "TOOL4D_SKIP_ONSTARTUP",
+            default_value_t = true,
+            action = ArgAction::Set
+        )]
+        skip_onstartup: bool,
+
+        /// Open the project without a data file.
+        #[arg(
+            long,
+            env = "TOOL4D_DATALESS",
+            default_value_t = true,
+            action = ArgAction::Set
+        )]
+        dataless: bool,
+
+        /// Diagnostic log level passed to tool4d.
+        #[arg(long, env = "TOOL4D_LOG_LEVEL")]
+        log_level: Option<String>,
+    },
 }
 
 fn main() -> ExitCode {
@@ -243,6 +298,28 @@ fn run() -> Result<()> {
             log_level.as_deref(),
             json,
             &files,
+        ),
+
+        BridgeCommand::Mcp {
+            tool,
+            project,
+            workspace,
+            port,
+            startup_timeout,
+            shutdown_timeout,
+            skip_onstartup,
+            dataless,
+            log_level,
+        } => run_mcp_server(
+            tool.as_deref(),
+            project.as_deref(),
+            workspace.as_deref(),
+            port,
+            Duration::from_secs(startup_timeout),
+            Duration::from_secs(shutdown_timeout),
+            skip_onstartup,
+            dataless,
+            log_level.as_deref(),
         ),
     }
 }
@@ -337,6 +414,173 @@ fn launch(
 // ---------------------------------------------------------------------------
 // Validate subcommand
 // ---------------------------------------------------------------------------
+
+#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments)]
+fn run_mcp_server(
+    requested_tool: Option<&Path>,
+    explicit_project: Option<&Path>,
+    workspace: Option<&Path>,
+    requested_port: Option<u16>,
+    startup_timeout: Duration,
+    shutdown_timeout: Duration,
+    skip_onstartup: bool,
+    dataless: bool,
+    log_level: Option<&str>,
+) -> Result<()> {
+    let tool = resolve_tool(requested_tool)?;
+    let project = resolve_project(explicit_project, workspace)?;
+    let cancellation = install_signal_handlers()?;
+
+    let workspace_dir = workspace
+        .map(Path::to_path_buf)
+        .or_else(|| {
+            explicit_project
+                .and_then(|p| p.parent())
+                .and_then(|p| p.parent())
+                .map(Path::to_path_buf)
+        })
+        .unwrap_or_else(|| env::current_dir().unwrap_or_default());
+
+    let workspace_dir = workspace_dir
+        .canonicalize()
+        .unwrap_or(workspace_dir);
+
+    let listener = create_listener(requested_port)?;
+    let listener_address = listener
+        .local_addr()
+        .context("failed to obtain the bridge listener address")?;
+
+    let port = listener_address.port();
+
+    let mut command = Command::new(&tool);
+
+    command
+        .arg(format!("--project={}", project.display()))
+        .arg(format!("--lsp={port}"))
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::inherit());
+
+    if skip_onstartup {
+        command.arg("--skip-onstartup");
+    }
+
+    if dataless {
+        command.arg("--dataless");
+    }
+
+    if let Some(log_level) = log_level {
+        command.arg(format!("--log-level={log_level}"));
+    }
+
+    configure_process_supervision(&mut command);
+
+    eprintln!("tool4d-lsp-stdio: listening for tool4d on {listener_address}");
+    log_command(&tool, command.get_args());
+
+    let mut child = command
+        .spawn()
+        .with_context(|| format!("failed to start {}", tool.display()))?;
+
+    if let Some(stdout) = child.stdout.take() {
+        forward_tool4d_stdout(stdout);
+    }
+
+    let mut child = match ChildGuard::new(child, shutdown_timeout) {
+        Ok(child) => child,
+        Err((mut child, error)) => {
+            let _ = child.kill();
+            let _ = child.wait();
+            return Err(error).context("failed to install process supervision for tool4d");
+        }
+    };
+
+    let mut stream = accept_with_timeout(&listener, &mut child, startup_timeout, &cancellation)?;
+    drop(listener);
+
+    // Perform LSP initialization.
+    let project_dir = project
+        .parent()
+        .and_then(|p| p.parent())
+        .unwrap_or(project.parent().unwrap_or(Path::new(".")));
+    let root_path = project_dir
+        .canonicalize()
+        .unwrap_or_else(|_| project_dir.to_path_buf());
+    let root_uri = path_to_file_uri(&root_path);
+
+    let initialize_params = serde_json::json!({
+        "processId": std::process::id(),
+        "capabilities": {
+            "textDocument": {
+                "publishDiagnostics": { "relatedInformation": true }
+            }
+        },
+        "rootUri": root_uri,
+        "workspaceFolders": [{
+            "uri": root_uri,
+            "name": project_dir.file_name()
+                .unwrap_or_default()
+                .to_string_lossy()
+        }],
+        "initializationOptions": {
+            "diagnostics": { "enable": true, "scope": "Workspace" },
+            "dependencies": { "enable": true }
+        }
+    });
+
+    send_lsp_request(&mut stream, 1, "initialize", initialize_params)?;
+
+    let timeout = Duration::from_secs(60);
+    loop {
+        let msg = read_lsp_message(&mut stream, timeout)
+            .context("waiting for initialize response")?;
+        if msg.get("id") == Some(&serde_json::json!(1)) {
+            break;
+        }
+    }
+
+    send_lsp_notification(&mut stream, "initialized", serde_json::json!({}))?;
+
+    // Drain any startup notifications briefly.
+    let drain_timeout = Duration::from_secs(3);
+    loop {
+        match read_lsp_message(&mut stream, drain_timeout) {
+            Ok(_) => {}
+            Err(_) => break,
+        }
+    }
+
+    eprintln!("tool4d-lsp-stdio: LSP initialized, starting MCP server on stdio");
+
+    // Build the MCP server and run it.
+    let lsp = std::sync::Arc::new(mcp::LspConnection::new(stream, workspace_dir));
+    let server = mcp::Tool4dMcpServer::new(lsp);
+
+    let rt = tokio::runtime::Runtime::new().context("failed to create tokio runtime")?;
+    let result = rt.block_on(async {
+        use rmcp::ServiceExt;
+
+        let service = server
+            .serve(rmcp::transport::stdio())
+            .await
+            .map_err(|e| anyhow::anyhow!("MCP serve error: {e}"))?;
+
+        service
+            .waiting()
+            .await
+            .map_err(|e| anyhow::anyhow!("MCP server error: {e}"))?;
+
+        Ok(())
+    });
+
+    eprintln!("tool4d-lsp-stdio: MCP server stopped, shutting down tool4d");
+
+    // ChildGuard ensures tool4d is cleaned up on drop.
+    drop(child);
+
+    result
+}
 
 #[allow(clippy::too_many_arguments)]
 fn validate(

--- a/tool4d-lsp-stdio/src/mcp.rs
+++ b/tool4d-lsp-stdio/src/mcp.rs
@@ -1,0 +1,658 @@
+//! MCP server wrapping the 4D LSP connection.
+//!
+//! Keeps a persistent tool4d LSP session alive and exposes LSP capabilities
+//! as MCP tools that AI agents can call.
+
+use std::{
+    io::{Read, Write},
+    net::TcpStream,
+    path::{Path, PathBuf},
+    sync::atomic::{AtomicU64, Ordering},
+    time::Duration,
+};
+
+use rmcp::{
+    handler::server::wrapper::Parameters, schemars, tool, tool_router, ErrorData,
+};
+use serde_json::Value;
+
+/// Shared state for the LSP connection.
+pub struct LspConnection {
+    stream: std::sync::Mutex<TcpStream>,
+    next_id: AtomicU64,
+    workspace: PathBuf,
+}
+
+impl LspConnection {
+    pub fn new(stream: TcpStream, workspace: PathBuf) -> Self {
+        Self {
+            stream: std::sync::Mutex::new(stream),
+            next_id: AtomicU64::new(100),
+            workspace,
+        }
+    }
+
+    fn next_request_id(&self) -> u64 {
+        self.next_id.fetch_add(1, Ordering::SeqCst)
+    }
+
+    /// Send an LSP request and wait for the matching response.
+    fn request(&self, method: &str, params: Value) -> anyhow::Result<Value> {
+        let id = self.next_request_id();
+        let mut stream = self.stream.lock().map_err(|e| anyhow::anyhow!("{e}"))?;
+        send_lsp_request(&mut *stream, id, method, params)?;
+
+        let timeout = Duration::from_secs(60);
+        loop {
+            let msg = read_lsp_message(&mut *stream, timeout)?;
+            if msg.get("id") == Some(&serde_json::json!(id)) {
+                return Ok(msg);
+            }
+            // Discard notifications while waiting for our response.
+        }
+    }
+
+    /// Send an LSP notification (no response expected).
+    fn notify(&self, method: &str, params: Value) -> anyhow::Result<()> {
+        let mut stream = self.stream.lock().map_err(|e| anyhow::anyhow!("{e}"))?;
+        send_lsp_notification(&mut *stream, method, params)
+    }
+
+    /// Resolve a relative file path against the workspace.
+    fn resolve_uri(&self, file: &str) -> String {
+        let path = Path::new(file);
+        let absolute = if path.is_absolute() {
+            path.to_path_buf()
+        } else {
+            self.workspace.join(path)
+        };
+        let canonical = absolute.canonicalize().unwrap_or(absolute);
+        path_to_file_uri(&canonical)
+    }
+}
+
+// ── MCP Server ──────────────────────────────────────────────────────────
+
+/// The MCP server that exposes 4D LSP tools.
+#[derive(Clone)]
+pub struct Tool4dMcpServer {
+    lsp: std::sync::Arc<LspConnection>,
+}
+
+impl Tool4dMcpServer {
+    pub fn new(lsp: std::sync::Arc<LspConnection>) -> Self {
+        Self { lsp }
+    }
+}
+
+// ── Tool parameter types ────────────────────────────────────────────────
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+pub struct ValidateParams {
+    /// One or more .4dm file paths relative to the workspace.
+    #[schemars(description = "File paths to validate, relative to the Project/ workspace")]
+    pub files: Vec<String>,
+}
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+pub struct CompletionParams {
+    /// File path relative to the workspace.
+    #[schemars(description = "File path relative to the Project/ workspace")]
+    pub file: String,
+    /// Zero-based line number.
+    pub line: u32,
+    /// Zero-based character offset.
+    pub character: u32,
+}
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+pub struct HoverParams {
+    /// File path relative to the workspace.
+    #[schemars(description = "File path relative to the Project/ workspace")]
+    pub file: String,
+    /// Zero-based line number.
+    pub line: u32,
+    /// Zero-based character offset.
+    pub character: u32,
+}
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+pub struct GotoDefinitionParams {
+    /// File path relative to the workspace.
+    #[schemars(description = "File path relative to the Project/ workspace")]
+    pub file: String,
+    /// Zero-based line number.
+    pub line: u32,
+    /// Zero-based character offset.
+    pub character: u32,
+}
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+pub struct DocumentSymbolsParams {
+    /// File path relative to the workspace.
+    #[schemars(description = "File path relative to the Project/ workspace")]
+    pub file: String,
+}
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+pub struct OpenFileParams {
+    /// File path relative to the workspace.
+    #[schemars(description = "File path relative to the Project/ workspace")]
+    pub file: String,
+}
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+pub struct CloseFileParams {
+    /// File path relative to the workspace.
+    #[schemars(description = "File path relative to the Project/ workspace")]
+    pub file: String,
+}
+
+// ── Tool implementations ────────────────────────────────────────────────
+
+#[tool_router(server_handler)]
+impl Tool4dMcpServer {
+    #[tool(description = "Validate .4dm files for syntax errors using the 4D compiler. Returns diagnostics (errors, warnings) with file, line, column, severity, and message.")]
+    async fn validate(
+        &self,
+        Parameters(params): Parameters<ValidateParams>,
+    ) -> Result<String, ErrorData> {
+        let lsp = self.lsp.clone();
+        tokio::task::spawn_blocking(move || {
+            let mut all_results = Vec::new();
+
+            for file in &params.files {
+                let uri = lsp.resolve_uri(file);
+
+                // Open the file.
+                let abs_path = Path::new(
+                    uri.strip_prefix("file://").unwrap_or(&uri),
+                );
+                let content = std::fs::read_to_string(abs_path)
+                    .map_err(|e| ErrorData::internal_error(format!("failed to read {file}: {e}"), None))?;
+
+                lsp.notify(
+                    "textDocument/didOpen",
+                    serde_json::json!({
+                        "textDocument": {
+                            "uri": uri,
+                            "languageId": "4d",
+                            "version": 1,
+                            "text": content
+                        }
+                    }),
+                )
+                .map_err(|e| ErrorData::internal_error(e.to_string(), None))?;
+
+                // Request diagnostics (pull model).
+                let response = lsp
+                    .request(
+                        "textDocument/diagnostic",
+                        serde_json::json!({ "textDocument": { "uri": uri } }),
+                    )
+                    .map_err(|e| ErrorData::internal_error(e.to_string(), None))?;
+
+                // Parse diagnostics (handle tool4d null-result bug).
+                let items = response
+                    .get("result")
+                    .and_then(|r| r.get("items"))
+                    .and_then(|i| i.as_array())
+                    .cloned()
+                    .unwrap_or_default();
+
+                for item in &items {
+                    let range = item.get("range").and_then(|r| r.get("start"));
+                    let line = range
+                        .and_then(|r| r.get("line"))
+                        .and_then(|l| l.as_u64())
+                        .unwrap_or(0)
+                        + 1;
+                    let col = range
+                        .and_then(|r| r.get("character"))
+                        .and_then(|c| c.as_u64())
+                        .unwrap_or(0)
+                        + 1;
+                    let severity = match item
+                        .get("severity")
+                        .and_then(|s| s.as_u64())
+                        .unwrap_or(1)
+                    {
+                        1 => "error",
+                        2 => "warning",
+                        3 => "info",
+                        _ => "hint",
+                    };
+                    let message = item
+                        .get("message")
+                        .and_then(|m| m.as_str())
+                        .unwrap_or("unknown");
+
+                    all_results.push(format!("{file}:{line}:{col}: {severity}: {message}"));
+                }
+
+                if items.is_empty() {
+                    all_results.push(format!("{file}: clean (no diagnostics)"));
+                }
+
+                // Close the file.
+                let _ = lsp.notify(
+                    "textDocument/didClose",
+                    serde_json::json!({
+                        "textDocument": { "uri": uri }
+                    }),
+                );
+            }
+
+            Ok(all_results.join("\n"))
+        })
+        .await
+        .map_err(|e| ErrorData::internal_error(e.to_string(), None))?
+    }
+
+    #[tool(description = "Get code completions at a position in a .4dm file. Returns a list of completion items with labels, kinds, and details.")]
+    async fn completion(
+        &self,
+        Parameters(params): Parameters<CompletionParams>,
+    ) -> Result<String, ErrorData> {
+        let lsp = self.lsp.clone();
+        tokio::task::spawn_blocking(move || {
+            let uri = lsp.resolve_uri(&params.file);
+            let response = lsp
+                .request(
+                    "textDocument/completion",
+                    serde_json::json!({
+                        "textDocument": { "uri": uri },
+                        "position": {
+                            "line": params.line,
+                            "character": params.character
+                        }
+                    }),
+                )
+                .map_err(|e| ErrorData::internal_error(e.to_string(), None))?;
+
+            let result = response.get("result").cloned().unwrap_or(Value::Null);
+
+            // Format completions.
+            let items = if let Some(arr) = result.as_array() {
+                arr.clone()
+            } else if let Some(arr) = result.get("items").and_then(|i| i.as_array()) {
+                arr.clone()
+            } else {
+                return Ok("No completions available.".to_string());
+            };
+
+            let formatted: Vec<String> = items
+                .iter()
+                .take(50) // Limit to avoid huge responses.
+                .map(|item| {
+                    let label = item
+                        .get("label")
+                        .and_then(|l| l.as_str())
+                        .unwrap_or("?");
+                    let detail = item
+                        .get("detail")
+                        .and_then(|d| d.as_str())
+                        .unwrap_or("");
+                    if detail.is_empty() {
+                        label.to_string()
+                    } else {
+                        format!("{label} — {detail}")
+                    }
+                })
+                .collect();
+
+            if formatted.is_empty() {
+                Ok("No completions available.".to_string())
+            } else {
+                Ok(formatted.join("\n"))
+            }
+        })
+        .await
+        .map_err(|e| ErrorData::internal_error(e.to_string(), None))?
+    }
+
+    #[tool(description = "Get hover information (documentation, type signature) for a symbol at a position in a .4dm file.")]
+    async fn hover(
+        &self,
+        Parameters(params): Parameters<HoverParams>,
+    ) -> Result<String, ErrorData> {
+        let lsp = self.lsp.clone();
+        tokio::task::spawn_blocking(move || {
+            let uri = lsp.resolve_uri(&params.file);
+            let response = lsp
+                .request(
+                    "textDocument/hover",
+                    serde_json::json!({
+                        "textDocument": { "uri": uri },
+                        "position": {
+                            "line": params.line,
+                            "character": params.character
+                        }
+                    }),
+                )
+                .map_err(|e| ErrorData::internal_error(e.to_string(), None))?;
+
+            let result = response.get("result").cloned().unwrap_or(Value::Null);
+
+            if result.is_null() {
+                return Ok("No hover information available at this position.".to_string());
+            }
+
+            // Extract contents (can be string, MarkupContent, or array).
+            if let Some(contents) = result.get("contents") {
+                if let Some(s) = contents.as_str() {
+                    return Ok(s.to_string());
+                }
+                if let Some(value) = contents.get("value").and_then(|v| v.as_str()) {
+                    return Ok(value.to_string());
+                }
+                // Array of MarkedString.
+                if let Some(arr) = contents.as_array() {
+                    let parts: Vec<String> = arr
+                        .iter()
+                        .filter_map(|item| {
+                            item.as_str()
+                                .map(String::from)
+                                .or_else(|| item.get("value").and_then(|v| v.as_str()).map(String::from))
+                        })
+                        .collect();
+                    return Ok(parts.join("\n\n"));
+                }
+            }
+
+            Ok(serde_json::to_string_pretty(&result).unwrap_or_default())
+        })
+        .await
+        .map_err(|e| ErrorData::internal_error(e.to_string(), None))?
+    }
+
+    #[tool(description = "Find the definition location of a symbol at a position in a .4dm file.")]
+    async fn goto_definition(
+        &self,
+        Parameters(params): Parameters<GotoDefinitionParams>,
+    ) -> Result<String, ErrorData> {
+        let lsp = self.lsp.clone();
+        tokio::task::spawn_blocking(move || {
+            let uri = lsp.resolve_uri(&params.file);
+            let response = lsp
+                .request(
+                    "textDocument/definition",
+                    serde_json::json!({
+                        "textDocument": { "uri": uri },
+                        "position": {
+                            "line": params.line,
+                            "character": params.character
+                        }
+                    }),
+                )
+                .map_err(|e| ErrorData::internal_error(e.to_string(), None))?;
+
+            let result = response.get("result").cloned().unwrap_or(Value::Null);
+
+            if result.is_null() {
+                return Ok("No definition found at this position.".to_string());
+            }
+
+            format_locations(&result)
+        })
+        .await
+        .map_err(|e| ErrorData::internal_error(e.to_string(), None))?
+    }
+
+    #[tool(description = "List all symbols (methods, variables, classes) in a .4dm file.")]
+    async fn document_symbols(
+        &self,
+        Parameters(params): Parameters<DocumentSymbolsParams>,
+    ) -> Result<String, ErrorData> {
+        let lsp = self.lsp.clone();
+        tokio::task::spawn_blocking(move || {
+            let uri = lsp.resolve_uri(&params.file);
+            let response = lsp
+                .request(
+                    "textDocument/documentSymbol",
+                    serde_json::json!({ "textDocument": { "uri": uri } }),
+                )
+                .map_err(|e| ErrorData::internal_error(e.to_string(), None))?;
+
+            let result = response.get("result").cloned().unwrap_or(Value::Null);
+
+            if result.is_null() {
+                return Ok("No symbols found.".to_string());
+            }
+
+            if let Some(arr) = result.as_array() {
+                let formatted: Vec<String> = arr
+                    .iter()
+                    .map(|sym| {
+                        let name = sym.get("name").and_then(|n| n.as_str()).unwrap_or("?");
+                        let kind = sym
+                            .get("kind")
+                            .and_then(|k| k.as_u64())
+                            .map(symbol_kind_name)
+                            .unwrap_or("unknown");
+                        let line = sym
+                            .get("range")
+                            .or_else(|| sym.get("location").and_then(|l| l.get("range")))
+                            .and_then(|r| r.get("start"))
+                            .and_then(|s| s.get("line"))
+                            .and_then(|l| l.as_u64())
+                            .map(|l| l + 1)
+                            .unwrap_or(0);
+                        format!("  {name} ({kind}) line {line}")
+                    })
+                    .collect();
+
+                if formatted.is_empty() {
+                    Ok("No symbols found.".to_string())
+                } else {
+                    Ok(formatted.join("\n"))
+                }
+            } else {
+                Ok("No symbols found.".to_string())
+            }
+        })
+        .await
+        .map_err(|e| ErrorData::internal_error(e.to_string(), None))?
+    }
+
+    #[tool(description = "Open a .4dm file in the LSP session. Required before requesting completions, hover, or goto_definition on a file.")]
+    async fn open_file(
+        &self,
+        Parameters(params): Parameters<OpenFileParams>,
+    ) -> Result<String, ErrorData> {
+        let lsp = self.lsp.clone();
+        tokio::task::spawn_blocking(move || {
+            let uri = lsp.resolve_uri(&params.file);
+            let abs_path = Path::new(uri.strip_prefix("file://").unwrap_or(&uri));
+            let content = std::fs::read_to_string(abs_path)
+                .map_err(|e| ErrorData::internal_error(format!("failed to read {}: {e}", params.file), None))?;
+
+            lsp.notify(
+                "textDocument/didOpen",
+                serde_json::json!({
+                    "textDocument": {
+                        "uri": uri,
+                        "languageId": "4d",
+                        "version": 1,
+                        "text": content
+                    }
+                }),
+            )
+            .map_err(|e| ErrorData::internal_error(e.to_string(), None))?;
+
+            Ok(format!("Opened {}", params.file))
+        })
+        .await
+        .map_err(|e| ErrorData::internal_error(e.to_string(), None))?
+    }
+
+    #[tool(description = "Close a .4dm file in the LSP session. Call after you are done with completions/hover/goto_definition.")]
+    async fn close_file(
+        &self,
+        Parameters(params): Parameters<CloseFileParams>,
+    ) -> Result<String, ErrorData> {
+        let lsp = self.lsp.clone();
+        tokio::task::spawn_blocking(move || {
+            let uri = lsp.resolve_uri(&params.file);
+            lsp.notify(
+                "textDocument/didClose",
+                serde_json::json!({
+                    "textDocument": { "uri": uri }
+                }),
+            )
+            .map_err(|e| ErrorData::internal_error(e.to_string(), None))?;
+
+            Ok(format!("Closed {}", params.file))
+        })
+        .await
+        .map_err(|e| ErrorData::internal_error(e.to_string(), None))?
+    }
+}
+
+// ── Helper functions ────────────────────────────────────────────────────
+
+fn format_locations(result: &Value) -> Result<String, ErrorData> {
+    let locations = if result.is_array() {
+        result.as_array().unwrap().clone()
+    } else {
+        vec![result.clone()]
+    };
+
+    let formatted: Vec<String> = locations
+        .iter()
+        .filter_map(|loc| {
+            let uri = loc.get("uri").and_then(|u| u.as_str())?;
+            let range = loc.get("range")?;
+            let line = range.get("start")?.get("line")?.as_u64()? + 1;
+            let col = range.get("start")?.get("character")?.as_u64()? + 1;
+            // Strip file:// prefix for readability.
+            let path = uri.strip_prefix("file:///").unwrap_or(
+                uri.strip_prefix("file://").unwrap_or(uri),
+            );
+            Some(format!("{path}:{line}:{col}"))
+        })
+        .collect();
+
+    if formatted.is_empty() {
+        Ok("No definition found.".to_string())
+    } else {
+        Ok(formatted.join("\n"))
+    }
+}
+
+fn symbol_kind_name(kind: u64) -> &'static str {
+    match kind {
+        1 => "file",
+        2 => "module",
+        3 => "namespace",
+        4 => "package",
+        5 => "class",
+        6 => "method",
+        7 => "property",
+        8 => "field",
+        9 => "constructor",
+        10 => "enum",
+        11 => "interface",
+        12 => "function",
+        13 => "variable",
+        14 => "constant",
+        15 => "string",
+        16 => "number",
+        17 => "boolean",
+        18 => "array",
+        19 => "object",
+        20 => "key",
+        21 => "null",
+        22 => "enum member",
+        23 => "struct",
+        24 => "event",
+        25 => "operator",
+        26 => "type parameter",
+        _ => "unknown",
+    }
+}
+
+fn path_to_file_uri(path: &Path) -> String {
+    let path_str = path.to_string_lossy();
+    if path_str.starts_with('/') {
+        format!("file://{path_str}")
+    } else {
+        format!("file:///{path_str}")
+    }
+}
+
+// ── LSP I/O (sync) ─────────────────────────────────────────────────────
+
+fn send_lsp_request(
+    stream: &mut TcpStream,
+    id: u64,
+    method: &str,
+    params: Value,
+) -> anyhow::Result<()> {
+    let body = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": id,
+        "method": method,
+        "params": params
+    });
+    let body = serde_json::to_string(&body)?;
+    let header = format!("Content-Length: {}\r\n\r\n", body.len());
+    stream.write_all(header.as_bytes())?;
+    stream.write_all(body.as_bytes())?;
+    stream.flush()?;
+    Ok(())
+}
+
+fn send_lsp_notification(
+    stream: &mut TcpStream,
+    method: &str,
+    params: Value,
+) -> anyhow::Result<()> {
+    let body = serde_json::json!({
+        "jsonrpc": "2.0",
+        "method": method,
+        "params": params
+    });
+    let body = serde_json::to_string(&body)?;
+    let header = format!("Content-Length: {}\r\n\r\n", body.len());
+    stream.write_all(header.as_bytes())?;
+    stream.write_all(body.as_bytes())?;
+    stream.flush()?;
+    Ok(())
+}
+
+fn read_lsp_message(stream: &mut TcpStream, timeout: Duration) -> anyhow::Result<Value> {
+    stream.set_read_timeout(Some(timeout))?;
+
+    let mut header_buf = Vec::new();
+    let mut byte = [0u8; 1];
+
+    loop {
+        stream.read_exact(&mut byte)?;
+        header_buf.push(byte[0]);
+        if header_buf.ends_with(b"\r\n\r\n") {
+            break;
+        }
+        if header_buf.len() > 64 * 1024 {
+            anyhow::bail!("LSP header too large");
+        }
+    }
+
+    let header_str = std::str::from_utf8(&header_buf)?;
+    let content_length: usize = header_str
+        .lines()
+        .find_map(|line| {
+            let line = line.trim();
+            if line.to_ascii_lowercase().starts_with("content-length:") {
+                line.split_once(':')?.1.trim().parse().ok()
+            } else {
+                None
+            }
+        })
+        .ok_or_else(|| anyhow::anyhow!("missing Content-Length"))?;
+
+    let mut body = vec![0u8; content_length];
+    stream.read_exact(&mut body)?;
+
+    serde_json::from_slice(&body).map_err(Into::into)
+}


### PR DESCRIPTION
New 'mcp' subcommand starts a persistent MCP server on stdio that keeps a tool4d LSP session alive. Exposes 7 tools:
- validate: check .4dm files for syntax errors
- completion: code completion at a position
- hover: documentation/signature info
- goto_definition: find symbol definitions
- document_symbols: list symbols in a file
- open_file / close_file: manage LSP document sessions

Uses rmcp 3.1 (official MCP Rust SDK) with tokio async runtime. LSP I/O remains synchronous, bridged via spawn_blocking.