### PR TITLE
Fix mcp daemonize: bool re-exec args and missing open_file on attach

### DIFF
--- a/tool4d-lsp-stdio/src/main.rs
+++ b/tool4d-lsp-stdio/src/main.rs
@@ -1034,12 +1034,14 @@ fn mcp_daemonize(options: &StartOptions<'_>, idle_timeout: Duration) -> Result<(
         "--shutdown-timeout={}",
         options.shutdown_timeout.as_secs()
     ));
-    if options.skip_onstartup {
-        command.arg("--skip-onstartup");
-    }
-    if options.dataless {
-        command.arg("--dataless");
-    }
+    // Unlike the flags passed to the real tool4d executable elsewhere in
+    // this file, `--skip-onstartup`/`--dataless` here target this same
+    // binary's own CLI (re-exec'd as `mcp --internal-mcp-worker`), where
+    // they are declared with `action = ArgAction::Set` and therefore
+    // require an explicit `=true`/`=false` value rather than being bare
+    // presence flags.
+    command.arg(format!("--skip-onstartup={}", options.skip_onstartup));
+    command.arg(format!("--dataless={}", options.dataless));
     if let Some(log_level) = options.log_level {
         command.arg(format!("--log-level={log_level}"));
     }
@@ -1228,24 +1230,35 @@ fn dispatch_ipc_request(
 ) -> tool4d_lsp_stdio::ipc::IpcResponse {
     use tool4d_lsp_stdio::ipc::{IpcRequest, IpcResponse};
 
+    // Position/file-based capabilities require the file to already be open
+    // in this LSP session (`textDocument/didOpen`); a one-shot standalone
+    // call handles this itself via `run_standalone_one_shot`, but attached
+    // IPC requests hit `LspConnection` methods directly, so open (or
+    // re-open; `open_file` is idempotent) the file here first.
     let result = match request {
         IpcRequest::Validate { files } => lsp.validate_files(&files),
         IpcRequest::Hover {
             file,
             line,
             character,
-        } => lsp.hover(&file, line, character),
+        } => lsp.open_file(&file).and_then(|_| lsp.hover(&file, line, character)),
         IpcRequest::Completion {
             file,
             line,
             character,
-        } => lsp.completion(&file, line, character),
+        } => lsp
+            .open_file(&file)
+            .and_then(|_| lsp.completion(&file, line, character)),
         IpcRequest::GotoDefinition {
             file,
             line,
             character,
-        } => lsp.goto_definition(&file, line, character),
-        IpcRequest::DocumentSymbols { file } => lsp.document_symbols(&file),
+        } => lsp
+            .open_file(&file)
+            .and_then(|_| lsp.goto_definition(&file, line, character)),
+        IpcRequest::DocumentSymbols { file } => {
+            lsp.open_file(&file).and_then(|_| lsp.document_symbols(&file))
+        }
         IpcRequest::Ping => Ok("pong".to_string()),
         IpcRequest::Stop => unreachable!("Stop is handled before dispatch"),
     };


### PR DESCRIPTION
Fixes #42.

## Bug 1: daemonize always fails
`mcp_daemonize` re-execs the current binary as `mcp --internal-mcp-worker ...`,
but passed `--skip-onstartup`/`--dataless` as bare presence flags. These flags
are declared with `action = ArgAction::Set` (require an explicit value), so
the worker's own clap parser rejected the command line and exited instantly.
Since the daemonizing parent sets the worker's `stderr` to `Stdio::null()`,
this only surfaced as the generic "the daemonized MCP server exited before it
finished starting up" — no useful diagnostic. Fixed by always emitting
`--skip-onstartup=<bool>` / `--dataless=<bool>` explicitly.

Note: the other 3 call sites in `main.rs` (`launch`, `start_lsp_session`,
`validate`) correctly use bare flags because they spawn the real `tool4d`
executable, which does accept presence-only flags for these options. Only
the self-re-exec in `mcp_daemonize` needed the value-explicit form.

## Bug 2: attached one-shot calls return no hover/completion/etc info
`dispatch_ipc_request` (serving attached one-shot requests against a running
persistent server) called `hover`/`completion`/`goto_definition`/
`document_symbols` directly without first calling `open_file`, unlike the
standalone one-shot path (`run_standalone_one_shot`) which explicitly opens
the file first. 4D's LSP requires `textDocument/didOpen` before these
requests resolve anything, so every attached call against a freshly-started
persistent server returned "no information available" — even for valid
commands. Fixed by opening the file first in each dispatch branch.

## Verification
Manually tested end-to-end against a live 4D project:
- `mcp --project <path>` now daemonizes successfully, prints `pid=... port=...`.
- Attached `hover` on a valid command (`Table(`) now returns real docs;
  attached `hover` on an obsolete command (`Count tables`) still correctly
  reports no hover info.
- Attached `document-symbols` works.
- `mcp --stop --project <path>` cleanly stops both worker and tool4d child.
- Re-tested with `--skip-onstartup false --dataless false` to confirm both
  boolean branches round-trip.

`cargo test` and `cargo clippy --all-targets -- -D warnings` both pass.
